### PR TITLE
Prepend prefix only once

### DIFF
--- a/lib/metriks/librato_metrics_reporter.rb
+++ b/lib/metriks/librato_metrics_reporter.rb
@@ -105,10 +105,6 @@ module Metriks
         next if name.nil? || name.empty?
         name = name.to_s.gsub(/ +/, '_')
 
-        if prefix
-          name = "#{prefix}.#{name}"
-        end
-
         case metric
         when Metriks::Meter
           count = metric.count


### PR DESCRIPTION
The prefix is added twice.  Once in `#write` and once in `#datapoint`.  This removes one of the prefixes.
